### PR TITLE
fix docker volume mount instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ docker run -d \
     --name nagiosapi
     -p 9090:9090 \
     -e NAGIOS_STATUS_PATH=/usr/local/nagios/var/status.dat \
-    -v /usr/local/nagios/var/status.dat:/usr/local/nagios/var/status.dat
+    -v /usr/local/nagios/var/:/usr/local/nagios/var/:ro
     rmcintosh/nagiosapi
 ```
 


### PR DESCRIPTION
Found the `status.dat` file was only being read once on creation, and not updating.  The solution was to mount the directory.  Also added a `readonly` flag to prevent writing to anything in the mounted directory.

source: https://github.com/moby/moby/issues/15793#issuecomment-160429268
